### PR TITLE
Add `Close` to client interfaces

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/nats-io/nats.go"
 	"github.com/synadia-io/connect/model"
-	"time"
 )
 
 const HasMoreHeader = "Nats-Has-More"
@@ -54,6 +55,8 @@ type Client interface {
 	CaptureMetrics(filter CaptureFilter, cursor MetricsCursor) (*nats.Subscription, error)
 	CaptureEvents(filter CaptureFilter, cursor EventsCursor) (*nats.Subscription, error)
 	CaptureLogs(filter CaptureFilter, cursor LogCursor) (*nats.Subscription, error)
+
+	Close()
 }
 
 func NewClient(nc *nats.Conn, trace bool) (Client, error) {

--- a/library/client.go
+++ b/library/client.go
@@ -3,9 +3,10 @@ package library
 import (
 	"encoding/json"
 	"fmt"
+	"time"
+
 	"github.com/nats-io/nats.go"
 	"github.com/synadia-io/connect/model"
-	"time"
 )
 
 const HasMoreHeader = "Nats-Has-More"
@@ -34,6 +35,8 @@ type Client interface {
 
 	ListComponents(filter ComponentFilter, cursor ComponentCursor, opts ...Opt) error
 	GetComponent(runtimeId string, versionId string, kind model.ComponentKind, name string, opts ...Opt) (*model.Component, error)
+
+	Close()
 }
 
 func NewClient(nc *nats.Conn, trace bool) Client {


### PR DESCRIPTION
- Add `Close` to client interfaces to allow closing connections.

`Close` was already implemented for both clients, but not exposed via the interface.