### PR TITLE
Add GetX for logs, events, and metrics to client and CLI

### DIFF
--- a/cli/capture_command.go
+++ b/cli/capture_command.go
@@ -2,14 +2,15 @@ package cli
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/choria-io/fisk"
 	"github.com/synadia-io/connect/client"
 	"github.com/synadia-io/connect/model"
-	"os"
 )
 
 func init() {
-	registerCommand("capture", 3, configureCaptureCommand)
+	registerCommand("capture", 4, configureCaptureCommand)
 }
 
 type captureCommand struct {

--- a/cli/connector_command.go
+++ b/cli/connector_command.go
@@ -69,6 +69,15 @@ func configureConnectorCommand(parentCmd commandHost) {
 	undeploy := connectorCmd.Command("undeploy", "Undeploy a connector").Action(c.undeployConnector)
 	undeploy.Arg("id", "The id of the connector to undeploy").Required().StringVar(&c.id)
 	undeploy.Flag("force", "Force undeployment").UnNegatableBoolVar(&c.force)
+
+	logsCmd := connectorCmd.Command("logs", "List current logs for a connector").Alias("l").Action(c.getConnectorLogs)
+	logsCmd.Arg("id", "The id of the connector to get logs for").Required().StringVar(&c.id)
+
+	eventsCmd := connectorCmd.Command("events", "List current events for a connector").Alias("e").Action(c.getConnectorEvents)
+	eventsCmd.Arg("id", "The id of the connector to get events for").Required().StringVar(&c.id)
+
+	metricsCmd := connectorCmd.Command("metrics", "List current metrics for a connector").Alias("m").Action(c.getConnectorMetrics)
+	metricsCmd.Arg("id", "The id of the connector to get metrics for").Required().StringVar(&c.id)
 }
 
 func (c *connectorCommand) listConnectors(pc *fisk.ParseContext) error {
@@ -307,6 +316,42 @@ func (c *connectorCommand) undeployConnector(pc *fisk.ParseContext) error {
 	}
 
 	fmt.Printf("Undeployed %s\n", color.GreenString(c.id))
+
+	return nil
+}
+
+func (c *connectorCommand) getConnectorLogs(pc *fisk.ParseContext) error {
+	logs, err := controlClient().GetConnectorLogs(c.id, "", "")
+	if err != nil {
+		color.Red("Could not get logs for connector %s: %s", c.id, err)
+		os.Exit(1)
+	}
+
+	printLogs(logs)
+
+	return nil
+}
+
+func (c *connectorCommand) getConnectorEvents(pc *fisk.ParseContext) error {
+	events, err := controlClient().GetConnectorEvents(c.id, "", "")
+	if err != nil {
+		color.Red("Could not get events for connector %s: %s", c.id, err)
+		os.Exit(1)
+	}
+
+	printEvents(events)
+
+	return nil
+}
+
+func (c *connectorCommand) getConnectorMetrics(pc *fisk.ParseContext) error {
+	metrics, err := controlClient().GetConnectorMetrics(c.id, "", "")
+	if err != nil {
+		color.Red("Could not get metrics for connector %s: %s", c.id, err)
+		os.Exit(1)
+	}
+
+	printMetrics(metrics)
 
 	return nil
 }

--- a/cli/instance_command.go
+++ b/cli/instance_command.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/choria-io/fisk"
+	"github.com/fatih/color"
+)
+
+func init() {
+	registerCommand("instance", 3, configureInstanceCommand)
+}
+
+type instanceCommand struct {
+	connectorId  string
+	deploymentId string
+	instanceId   string
+}
+
+func configureInstanceCommand(parentCmd commandHost) {
+	c := &instanceCommand{}
+
+	instanceCmd := parentCmd.Command("instance", "Interact with instances").Alias("i")
+
+	logsCmd := instanceCmd.Command("logs", "List current logs for an instance").Action(c.getInstanceLogs)
+	logsCmd.Arg("connector", "The connector to get logs for").Required().StringVar(&c.connectorId)
+	logsCmd.Arg("deployment", "The deployment to get logs for").StringVar(&c.deploymentId)
+	logsCmd.Arg("id", "The instance to get logs for").StringVar(&c.instanceId)
+
+	eventsCmd := instanceCmd.Command("events", "List current events for an instance").Alias("e").Action(c.getInstanceEvents)
+	eventsCmd.Arg("connector", "The connector to get events for").Required().StringVar(&c.connectorId)
+	eventsCmd.Arg("deployment", "The deployment to get events for").StringVar(&c.deploymentId)
+	eventsCmd.Arg("id", "The instance to get events for").StringVar(&c.instanceId)
+
+	metricsCmd := instanceCmd.Command("metrics", "List current metrics for an instance").Alias("m").Action(c.getInstanceMetrics)
+	metricsCmd.Arg("connector", "The connector to get metrics for").Required().StringVar(&c.connectorId)
+	metricsCmd.Arg("deployment", "The deployment to get metrics for").StringVar(&c.deploymentId)
+	metricsCmd.Arg("id", "The instance to get metrics for").StringVar(&c.instanceId)
+}
+
+func (c *instanceCommand) getInstanceLogs(pc *fisk.ParseContext) error {
+	logs, err := controlClient().GetConnectorLogs(c.connectorId, c.deploymentId, c.instanceId)
+	if err != nil {
+		color.Red("Could not get logs for instance %s: %s", c.instanceId, err)
+		os.Exit(1)
+	}
+
+	printLogs(logs)
+
+	return nil
+}
+
+func (c *instanceCommand) getInstanceEvents(pc *fisk.ParseContext) error {
+	events, err := controlClient().GetConnectorEvents(c.connectorId, c.deploymentId, c.instanceId)
+	if err != nil {
+		color.Red("Could not get events for instance %s: %s", c.instanceId, err)
+		os.Exit(1)
+	}
+
+	printEvents(events)
+
+	return nil
+}
+
+func (c *instanceCommand) getInstanceMetrics(pc *fisk.ParseContext) error {
+	metrics, err := controlClient().GetConnectorMetrics(c.connectorId, c.deploymentId, c.instanceId)
+	if err != nil {
+		color.Red("Could not get metrics for instance %s: %s", c.instanceId, err)
+		os.Exit(1)
+	}
+
+	printMetrics(metrics)
+
+	return nil
+}

--- a/cli/print.go
+++ b/cli/print.go
@@ -1,0 +1,74 @@
+package cli
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/synadia-io/connect/model"
+)
+
+func printLogs(logs []*model.InstanceLog) {
+	if len(logs) == 0 {
+		fmt.Print("No logs found\n")
+		return
+	}
+
+	for _, log := range logs {
+		if log == nil {
+			continue
+		}
+
+		fmt.Printf("[%v %v %v] %v\n", log.ConnectorId, log.DeploymentId, log.InstanceId, log.Line)
+	}
+}
+
+func printEvents(events []*model.InstanceEvent) {
+	if len(events) == 0 {
+		fmt.Print("No events found\n")
+		return
+	}
+
+	// Check if any events have a local timezone
+	var localTz *time.Location
+	for _, event := range events {
+		loc := event.Timestamp.Location()
+		if loc != time.UTC {
+			localTz = loc
+			break
+		}
+	}
+	if localTz == nil {
+		localTz = time.UTC
+	}
+
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+
+		// Show all events in the same timezone, even if some are local and some are UTC
+		ts := event.Timestamp.In(localTz)
+		msg := fmt.Sprintf("[%v %v %v] %v %v", event.ConnectorId, event.DeploymentId, event.InstanceId, ts.Format(time.RFC3339), event.Type)
+		if event.ExitCode != 0 {
+			msg = fmt.Sprintf("%v %v %v", msg, event.ExitCode, event.Error)
+		}
+
+		fmt.Printf("%v\n", msg)
+	}
+}
+
+func printMetrics(metrics []*model.InstanceMetric) {
+	if len(metrics) == 0 {
+		fmt.Print("No metrics found\n")
+		return
+	}
+
+	for _, metric := range metrics {
+		if metric == nil {
+			continue
+		}
+
+		fmt.Printf("[%v %v %v] %v\n", metric.ConnectorId, metric.DeploymentId, metric.InstanceId, metric.Timestamp.Format(time.RFC3339))
+		fmt.Printf("%v\n", string(metric.Data)) // print the raw prometheus metric data
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -46,6 +46,10 @@ type Client interface {
 	RedeployConnector(id string, opts ...RedeployOpt) (*ConnectorRedeployResult, error)
 	UndeployConnector(id string, opts ...UndeployOpt) (*ConnectorUndeployResult, error)
 
+	GetConnectorLogs(connectorId, deploymentId, instanceId string, opts ...Opt) ([]*model.InstanceLog, error)
+	GetConnectorEvents(connectorId, deploymentId, instanceId string, opts ...Opt) ([]*model.InstanceEvent, error)
+	GetConnectorMetrics(connectorId, deploymentId, instanceId string, opts ...Opt) ([]*model.InstanceMetric, error)
+
 	ListDeployments(filter DeploymentFilter, cursor DeploymentCursor, opts ...Opt) error
 	GetDeployment(connectorId string, deploymentId string, opts ...Opt) (*model.Deployment, error)
 	PurgeDeployments(filter DeploymentFilter, cursor DeploymentPurgeCursor, opts ...Opt) error

--- a/client/connector_events.go
+++ b/client/connector_events.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/synadia-io/connect/model"
+)
+
+type (
+	getConnectorEventsRequest struct {
+		ConnectorId  string `json:"connector_id"`
+		DeploymentId string `json:"deployment_id,omitempty"`
+		InstanceId   string `json:"instance_id,omitempty"`
+	}
+)
+
+func (c *client) GetConnectorEvents(connectorId, deploymentId, instanceId string, opts ...Opt) ([]*model.InstanceEvent, error) {
+	req := getConnectorEventsRequest{
+		ConnectorId:  connectorId,
+		DeploymentId: deploymentId,
+		InstanceId:   instanceId,
+	}
+
+	b, err := c.Request(c.serviceSubject("CONNECTOR.EVENTS"), req, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []*model.InstanceEvent
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/client/connector_logs.go
+++ b/client/connector_logs.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/synadia-io/connect/model"
+)
+
+type (
+	getConnectorLogsRequest struct {
+		ConnectorId  string `json:"connector_id"`
+		DeploymentId string `json:"deployment_id,omitempty"`
+		InstanceId   string `json:"instance_id,omitempty"`
+	}
+)
+
+func (c *client) GetConnectorLogs(connectorId, deploymentId, instanceId string, opts ...Opt) ([]*model.InstanceLog, error) {
+	req := getConnectorLogsRequest{
+		ConnectorId:  connectorId,
+		DeploymentId: deploymentId,
+		InstanceId:   instanceId,
+	}
+
+	b, err := c.Request(c.serviceSubject("CONNECTOR.LOGS"), req, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []*model.InstanceLog
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/client/connector_metrics.go
+++ b/client/connector_metrics.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/synadia-io/connect/model"
+)
+
+type (
+	getConnectorMetricsRequest struct {
+		ConnectorId  string `json:"connector_id"`
+		DeploymentId string `json:"deployment_id,omitempty"`
+		InstanceId   string `json:"instance_id,omitempty"`
+	}
+)
+
+func (c *client) GetConnectorMetrics(connectorId, deploymentId, instanceId string, opts ...Opt) ([]*model.InstanceMetric, error) {
+	req := getConnectorMetricsRequest{
+		ConnectorId:  connectorId,
+		DeploymentId: deploymentId,
+		InstanceId:   instanceId,
+	}
+
+	b, err := c.Request(c.serviceSubject("CONNECTOR.METRICS"), req, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp []*model.InstanceMetric
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
Logs with `connector`:
```
❯ ./connect connector logs hello | head
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9ZT] 2025-01-09T04:40:53.018988555Z {"level":"info","time":"2025-01-09T04:40:53Z","message":"stream def: aW5wdXQ6CiAgICBsYWJlbDogIiIKICAgIGdlbmVyYXRlOgogICAgICAgIG1hcHBpbmc6IHJvb3QubWVzc2FnZSA9ICJoZWxsbyIKICAgICAgICBpbnRlcnZhbDogMXMKICAgICAgICBjb3VudDogMAogICAgICAgIGJhdGNoX3NpemU6IDAKICAgICAgICBhdXRvX3JlcGxheV9uYWNrczogdHJ1ZQpidWZmZXI6CiAgICBub25lOiB7fQpwaXBlbGluZToKICAgIHRocmVhZHM6IC0xCiAgICBwcm9jZXNzb3JzOiBbXQpvdXRwdXQ6CiAgICBsYWJlbDogIiIKICAgIG5hdHM6CiAgICAgICAgdXJsczoKICAgICAgICAgICAgLSBuYXRzOi8vZGVtby5uYXRzLmlvOjQyMjIKICAgICAgICBzdWJqZWN0OiB2ZW50LmpvZS5oZWxsbwogICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICBpbmNsdWRlX3BhdHRlcm5zOgogICAgICAgICAgICAgICAgLSAuKgogICAgICAgIG1heF9pbl9mbGlnaHQ6IDEKbWV0cmljczoKICAgIHByb21ldGhldXM6IHt9CiAgICBtYXBwaW5nOiAiIgp0cmFjZXI6CiAgICBub25lOiB7fQo="}
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9YS] 2025-01-09T04:40:53.019096805Z {"level":"info","time":"2025-01-09T04:40:53Z","message":"stream def: aW5wdXQ6CiAgICBsYWJlbDogIiIKICAgIGdlbmVyYXRlOgogICAgICAgIG1hcHBpbmc6IHJvb3QubWVzc2FnZSA9ICJoZWxsbyIKICAgICAgICBpbnRlcnZhbDogMXMKICAgICAgICBjb3VudDogMAogICAgICAgIGJhdGNoX3NpemU6IDAKICAgICAgICBhdXRvX3JlcGxheV9uYWNrczogdHJ1ZQpidWZmZXI6CiAgICBub25lOiB7fQpwaXBlbGluZToKICAgIHRocmVhZHM6IC0xCiAgICBwcm9jZXNzb3JzOiBbXQpvdXRwdXQ6CiAgICBsYWJlbDogIiIKICAgIG5hdHM6CiAgICAgICAgdXJsczoKICAgICAgICAgICAgLSBuYXRzOi8vZGVtby5uYXRzLmlvOjQyMjIKICAgICAgICBzdWJqZWN0OiB2ZW50LmpvZS5oZWxsbwogICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICBpbmNsdWRlX3BhdHRlcm5zOgogICAgICAgICAgICAgICAgLSAuKgogICAgICAgIG1heF9pbl9mbGlnaHQ6IDEKbWV0cmljczoKICAgIHByb21ldGhldXM6IHt9CiAgICBtYXBwaW5nOiAiIgp0cmFjZXI6CiAgICBub25lOiB7fQo="}
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9ZT] 2025-01-09T04:40:53.019288555Z 2025/01/09 04:40:53 INFO Input type generate is now active path=root.input label=""
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9YS] 2025-01-09T04:40:53.019620139Z 2025/01/09 04:40:53 INFO Input type generate is now active path=root.input label=""
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9XR] 2025-01-09T04:40:53.109377889Z {"level":"info","time":"2025-01-09T04:40:53Z","message":"stream def: aW5wdXQ6CiAgICBsYWJlbDogIiIKICAgIGdlbmVyYXRlOgogICAgICAgIG1hcHBpbmc6IHJvb3QubWVzc2FnZSA9ICJoZWxsbyIKICAgICAgICBpbnRlcnZhbDogMXMKICAgICAgICBjb3VudDogMAogICAgICAgIGJhdGNoX3NpemU6IDAKICAgICAgICBhdXRvX3JlcGxheV9uYWNrczogdHJ1ZQpidWZmZXI6CiAgICBub25lOiB7fQpwaXBlbGluZToKICAgIHRocmVhZHM6IC0xCiAgICBwcm9jZXNzb3JzOiBbXQpvdXRwdXQ6CiAgICBsYWJlbDogIiIKICAgIG5hdHM6CiAgICAgICAgdXJsczoKICAgICAgICAgICAgLSBuYXRzOi8vZGVtby5uYXRzLmlvOjQyMjIKICAgICAgICBzdWJqZWN0OiB2ZW50LmpvZS5oZWxsbwogICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICBpbmNsdWRlX3BhdHRlcm5zOgogICAgICAgICAgICAgICAgLSAuKgogICAgICAgIG1heF9pbl9mbGlnaHQ6IDEKbWV0cmljczoKICAgIHByb21ldGhldXM6IHt9CiAgICBtYXBwaW5nOiAiIgp0cmFjZXI6CiAgICBub25lOiB7fQo="}
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9XR] 2025-01-09T04:40:53.109699472Z 2025/01/09 04:40:53 INFO Input type generate is now active path=root.input label=""
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9ZT] 2025-01-09T04:40:53.324919139Z 2025/01/09 04:40:53 INFO Output type nats is now active path=root.output label=""
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9YS] 2025-01-09T04:40:53.335037097Z 2025/01/09 04:40:53 INFO Output type nats is now active path=root.output label=""
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9XR] 2025-01-09T04:40:53.353691930Z 2025/01/09 04:40:53 INFO Output type nats is now active path=root.output label=""
[hello DvzoTSQvVvqsLFvLFJi9aU DvzoTSQvVvqsLFvLFJi9XR] 2025-01-09T04:40:53.109377889Z {"level":"info","time":"2025-01-09T04:40:53Z","message":"stream def: aW5wdXQ6CiAgICBsYWJlbDogIiIKICAgIGdlbmVyYXRlOgogICAgICAgIG1hcHBpbmc6IHJvb3QubWVzc2FnZSA9ICJoZWxsbyIKICAgICAgICBpbnRlcnZhbDogMXMKICAgICAgICBjb3VudDogMAogICAgICAgIGJhdGNoX3NpemU6IDAKICAgICAgICBhdXRvX3JlcGxheV9uYWNrczogdHJ1ZQpidWZmZXI6CiAgICBub25lOiB7fQpwaXBlbGluZToKICAgIHRocmVhZHM6IC0xCiAgICBwcm9jZXNzb3JzOiBbXQpvdXRwdXQ6CiAgICBsYWJlbDogIiIKICAgIG5hdHM6CiAgICAgICAgdXJsczoKICAgICAgICAgICAgLSBuYXRzOi8vZGVtby5uYXRzLmlvOjQyMjIKICAgICAgICBzdWJqZWN0OiB2ZW50LmpvZS5oZWxsbwogICAgICAgIG1ldGFkYXRhOgogICAgICAgICAgICBpbmNsdWRlX3BhdHRlcm5zOgogICAgICAgICAgICAgICAgLSAuKgogICAgICAgIG1heF9pbl9mbGlnaHQ6IDEKbWV0cmljczoKICAgIHByb21ldGhldXM6IHt9CiAgICBtYXBwaW5nOiAiIgp0cmFjZXI6CiAgICBub25lOiB7fQo="}
...
```

Events w/ `deployment`:
```
❯ ./connect deployment events hello 5GuQKVEKNePBarlbxEwQ6F
[hello 5GuQKVEKNePBarlbxEwQ6F 5GuQKVEKNePBarlbxEwQ3K] 2025-01-08T23:41:33-07:00 scheduled
[hello 5GuQKVEKNePBarlbxEwQ6F 5GuQKVEKNePBarlbxEwQ3K] 1970-01-20T19:20:04-07:00 created
[hello 5GuQKVEKNePBarlbxEwQ6F 5GuQKVEKNePBarlbxEwQ3K] 2025-01-08T23:41:33-07:00 running
```

Metrics w/ `instance`:
```
❯ ./connect instance metrics hello 5GuQKVEKNePBarlbxEwQ6F 5GuQKVEKNePBarlbxEwQ3K | head
[hello 5GuQKVEKNePBarlbxEwQ6F 5GuQKVEKNePBarlbxEwQ3K] 2025-01-09T00:11:32-07:00
# HELP input_connection_failed Benthos Counter metric
# TYPE input_connection_failed counter
input_connection_failed{label="",path="root.input"} 0
# HELP input_connection_lost Benthos Counter metric
# TYPE input_connection_lost counter
input_connection_lost{label="",path="root.input"} 0
# HELP input_connection_up Benthos Counter metric
# TYPE input_connection_up counter
input_connection_up{label="",path="root.input"} 1
...
```