### PR TITLE
fix: connector copy command should not require a runtime version arg

### DIFF
--- a/cli/connector_command.go
+++ b/cli/connector_command.go
@@ -47,7 +47,6 @@ type connectorCommand struct {
 	targetId string
 
 	runtime          string
-	runtimeVersion   string
 	envFileSetByUser bool
 }
 
@@ -72,7 +71,6 @@ func ConfigureConnectorCommand(parentCmd commandHost, opts *Options) {
 	copyCmd := connectorCmd.Command("copy", "Copy a connector").Action(c.copyConnector)
 	copyCmd.Arg("id", "The id of the connector to copy").Required().StringVar(&c.id)
 	copyCmd.Arg("target-id", "The id of the new connector").Required().StringVar(&c.targetId)
-	copyCmd.Flag("runtime-version", "The runtime version for the new connector").Required().StringVar(&c.runtimeVersion)
 
 	deleteCmd := connectorCmd.Command("delete", "Delete a connector").Alias("rm").Action(c.removeConnector)
 	deleteCmd.Arg("connector", "The name of the connector").Required().StringVar(&c.id)
@@ -432,7 +430,7 @@ func (c *connectorCommand) copyConnector(context *fisk.ParseContext) error {
 		return nil
 	}
 
-	_, err = appCtx.Client.CreateConnector(c.targetId, conn.Description, conn.RuntimeId, c.runtimeVersion, convert.ConvertStepsFromSpec(convert.ConvertStepsToSpec(conn.Steps)), c.opts.Timeout)
+	_, err = appCtx.Client.CreateConnector(c.targetId, conn.Description, conn.RuntimeId, conn.RuntimeVersion, convert.ConvertStepsFromSpec(convert.ConvertStepsToSpec(conn.Steps)), c.opts.Timeout)
 	fisk.FatalIfError(err, "failed to create connector %s: %v", c.targetId, err)
 
 	fmt.Printf("Created connector %s\n", color.GreenString(c.targetId))

--- a/cli/connector_command_helpers.go
+++ b/cli/connector_command_helpers.go
@@ -142,7 +142,7 @@ func (c *connectorCommand) copyConnectorWithClient(appCtx *AppContext) error {
 	}
 
 	// Create the copy
-	copied, err := appCtx.Client.CreateConnector(c.targetId, connector.Description, connector.RuntimeId, c.runtimeVersion, connector.Steps, c.opts.Timeout)
+	copied, err := appCtx.Client.CreateConnector(c.targetId, connector.Description, connector.RuntimeId, connector.RuntimeVersion, connector.Steps, c.opts.Timeout)
 	if err != nil {
 		return fmt.Errorf("failed to create connector copy: %w", err)
 	}

--- a/cli/connector_command_test.go
+++ b/cli/connector_command_test.go
@@ -264,9 +264,10 @@ var _ = Describe("ConnectorCommand", func() {
 		It("should copy a connector", func() {
 			// First it gets the source connector
 			mockCl.connector = &model.Connector{
-				ConnectorId: "source-connector",
-				Description: "Source Connector",
-				RuntimeId:   "synadia",
+				ConnectorId:    "source-connector",
+				Description:    "Source Connector",
+				RuntimeId:      "synadia",
+				RuntimeVersion: "v1.0.0",
 				Steps: model.Steps{
 					Source: &model.SourceStep{
 						Type: "generate",


### PR DESCRIPTION
- `connector copy` should not care about the runtime version being used in the connector
- should just use the runtime version set on the source connector
